### PR TITLE
Check if ffmpeg open was successful before reading image frame

### DIFF
--- a/haffmpeg/tools.py
+++ b/haffmpeg/tools.py
@@ -75,6 +75,11 @@ class ImageFrame(HAFFmpeg):
             cmd=command, input_source=input_source, output="-f image2pipe -",
             extra_cmd=extra_cmd)
 
+        # error after open?
+        if self._proc is None:
+            _LOGGER.warning("Error starting FFmpeg.")
+            return None
+
         # read image
         try:
             with async_timeout.timeout(timeout, loop=self._loop):


### PR DESCRIPTION
HAFFmpeg open can fail in case FFmpeg fails, so check for self._proc
before using it to read the image frame.

Fixes:

File "/usr/lib/python3.6/site-packages/haffmpeg/tools.py", line 82, in get_image
    self._proc.communicate(), loop=self._loop)
AttributeError: 'NoneType' object has no attribute 'communicate'

Signed-off-by: Ricardo Salveti <rsalveti@rsalveti.net>